### PR TITLE
geom_alt props

### DIFF
--- a/data/421/167/647/421167647.geojson
+++ b/data/421/167/647/421167647.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459008739,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23c13a9999e5e9fef37927dde5b3a149",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421167647,
-    "wof:lastmodified":1566654442,
+    "wof:lastmodified":1582359450,
     "wof:name":"Duku",
     "wof:parent_id":1108563243,
     "wof:placetype":"locality",

--- a/data/421/169/331/421169331.geojson
+++ b/data/421/169/331/421169331.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459008805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17a63d8df7df13ef039a5ba55e39993d",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421169331,
-    "wof:lastmodified":1566654443,
+    "wof:lastmodified":1582359451,
     "wof:name":"Tarauni",
     "wof:parent_id":85675425,
     "wof:placetype":"county",

--- a/data/421/169/465/421169465.geojson
+++ b/data/421/169/465/421169465.geojson
@@ -166,6 +166,7 @@
     "qs:woe_id":1392886,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "src:population":"quattroshapes",
@@ -188,6 +189,10 @@
     },
     "wof:country":"NG",
     "wof:created":1459008811,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1a4e6c04918a375b4b46a37ea65d1054",
     "wof:hierarchy":[
         {
@@ -199,7 +204,7 @@
         }
     ],
     "wof:id":421169465,
-    "wof:lastmodified":1566654444,
+    "wof:lastmodified":1582359451,
     "wof:name":"Gombe",
     "wof:parent_id":1108562965,
     "wof:placetype":"locality",

--- a/data/421/171/053/421171053.geojson
+++ b/data/421/171/053/421171053.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459008880,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a128cf6a02c2b3b1a063d8785dc45eeb",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421171053,
-    "wof:lastmodified":1566654467,
+    "wof:lastmodified":1582359453,
     "wof:name":"Mushin",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/171/055/421171055.geojson
+++ b/data/421/171/055/421171055.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459008880,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91a0343de712c5a8087db5066043386e",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421171055,
-    "wof:lastmodified":1566654467,
+    "wof:lastmodified":1582359453,
     "wof:name":"Shomolu",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/171/305/421171305.geojson
+++ b/data/421/171/305/421171305.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459008889,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f927714185aceeb16f648393faf4f50",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421171305,
-    "wof:lastmodified":1566654467,
+    "wof:lastmodified":1582359453,
     "wof:name":"Ibeju/Lekki",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/171/419/421171419.geojson
+++ b/data/421/171/419/421171419.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459008893,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e8114ba258ae58235254e9382980ce1",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421171419,
-    "wof:lastmodified":1566654467,
+    "wof:lastmodified":1582359453,
     "wof:name":"Okigwe",
     "wof:parent_id":85675315,
     "wof:placetype":"county",

--- a/data/421/174/885/421174885.geojson
+++ b/data/421/174/885/421174885.geojson
@@ -221,6 +221,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009047,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"657c9c87ebd477395281a301d13e7f84",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         }
     ],
     "wof:id":421174885,
-    "wof:lastmodified":1566654446,
+    "wof:lastmodified":1582359452,
     "wof:name":"Orlu",
     "wof:parent_id":85675315,
     "wof:placetype":"county",

--- a/data/421/175/165/421175165.geojson
+++ b/data/421/175/165/421175165.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de42836a89f26260aaf69cbe202f8b0c",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421175165,
-    "wof:lastmodified":1566654452,
+    "wof:lastmodified":1582359452,
     "wof:name":"Surulere",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/176/769/421176769.geojson
+++ b/data/421/176/769/421176769.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009118,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"caaaf02304f6efc8e43343b39b802caa",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421176769,
-    "wof:lastmodified":1566654467,
+    "wof:lastmodified":1582359453,
     "wof:name":"Ifedore",
     "wof:parent_id":85675357,
     "wof:placetype":"county",

--- a/data/421/178/395/421178395.geojson
+++ b/data/421/178/395/421178395.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4f8f47361d8e62caed2c82d847c62b5",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421178395,
-    "wof:lastmodified":1566654465,
+    "wof:lastmodified":1582359453,
     "wof:name":"Abuja Municipal",
     "wof:parent_id":85675457,
     "wof:placetype":"county",

--- a/data/421/181/827/421181827.geojson
+++ b/data/421/181/827/421181827.geojson
@@ -170,6 +170,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009308,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1ff5a144297c2d4870256b154a14043",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":421181827,
-    "wof:lastmodified":1566654451,
+    "wof:lastmodified":1582359452,
     "wof:name":"Ikeja",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/182/813/421182813.geojson
+++ b/data/421/182/813/421182813.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009348,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a9ae4d555fcedd0e9baca1e950820d6",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421182813,
-    "wof:lastmodified":1566654466,
+    "wof:lastmodified":1582359453,
     "wof:name":"Gurara",
     "wof:parent_id":85675349,
     "wof:placetype":"county",

--- a/data/421/183/191/421183191.geojson
+++ b/data/421/183/191/421183191.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009361,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8bf074699a98bfb99257324b6a57edb6",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         }
     ],
     "wof:id":421183191,
-    "wof:lastmodified":1566654462,
+    "wof:lastmodified":1582359453,
     "wof:name":"Jalingo",
     "wof:parent_id":85675335,
     "wof:placetype":"county",

--- a/data/421/183/285/421183285.geojson
+++ b/data/421/183/285/421183285.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009364,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2dec4ee79fccb531b0054169623e786d",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421183285,
-    "wof:lastmodified":1566654463,
+    "wof:lastmodified":1582359453,
     "wof:name":"Badagry",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/183/311/421183311.geojson
+++ b/data/421/183/311/421183311.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009365,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f9d57f7064bc5133347041daf7b8316",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421183311,
-    "wof:lastmodified":1566654463,
+    "wof:lastmodified":1582359453,
     "wof:name":"Bende",
     "wof:parent_id":85675305,
     "wof:placetype":"county",

--- a/data/421/185/431/421185431.geojson
+++ b/data/421/185/431/421185431.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009443,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"860068dd98a79a8c5cd5c6381966ff1d",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421185431,
-    "wof:lastmodified":1566654468,
+    "wof:lastmodified":1582359453,
     "wof:name":"Madagali",
     "wof:parent_id":85675451,
     "wof:placetype":"county",

--- a/data/421/186/467/421186467.geojson
+++ b/data/421/186/467/421186467.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009482,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5370c177b183917d4112404551c7c414",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421186467,
-    "wof:lastmodified":1566654451,
+    "wof:lastmodified":1582359452,
     "wof:name":"Enugu North",
     "wof:parent_id":85675395,
     "wof:placetype":"county",

--- a/data/421/186/507/421186507.geojson
+++ b/data/421/186/507/421186507.geojson
@@ -213,6 +213,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009483,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e99cca8207d092faf0c4c7905e040213",
     "wof:hierarchy":[
         {
@@ -223,7 +226,7 @@
         }
     ],
     "wof:id":421186507,
-    "wof:lastmodified":1566654451,
+    "wof:lastmodified":1582359452,
     "wof:name":"Bida",
     "wof:parent_id":85675349,
     "wof:placetype":"county",

--- a/data/421/187/947/421187947.geojson
+++ b/data/421/187/947/421187947.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009529,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98de1d5579071f8da4f343482a4f2ca8",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421187947,
-    "wof:lastmodified":1566654449,
+    "wof:lastmodified":1582359452,
     "wof:name":"Abeokuta North",
     "wof:parent_id":85675353,
     "wof:placetype":"county",

--- a/data/421/188/929/421188929.geojson
+++ b/data/421/188/929/421188929.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"234f2acc9a7e58a15af2be534c384537",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421188929,
-    "wof:lastmodified":1566654450,
+    "wof:lastmodified":1582359452,
     "wof:name":"Oredo",
     "wof:parent_id":85675391,
     "wof:placetype":"county",

--- a/data/421/188/931/421188931.geojson
+++ b/data/421/188/931/421188931.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009588,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"901c59276be0112e5c1b1fd9dc40b1c3",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421188931,
-    "wof:lastmodified":1566654450,
+    "wof:lastmodified":1582359452,
     "wof:name":"Obafemi-Owode",
     "wof:parent_id":85675353,
     "wof:placetype":"county",

--- a/data/421/189/471/421189471.geojson
+++ b/data/421/189/471/421189471.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009626,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea8b023bbfd9af9439dd6df370d6b6b7",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421189471,
-    "wof:lastmodified":1566654449,
+    "wof:lastmodified":1582359452,
     "wof:name":"Ibadan North East",
     "wof:parent_id":85675371,
     "wof:placetype":"county",

--- a/data/421/189/639/421189639.geojson
+++ b/data/421/189/639/421189639.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009631,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca1be9954053a83fe34e4fabf1a1a5db",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421189639,
-    "wof:lastmodified":1566654450,
+    "wof:lastmodified":1582359452,
     "wof:name":"Eti-Osa",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/196/611/421196611.geojson
+++ b/data/421/196/611/421196611.geojson
@@ -241,6 +241,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40ab6bf23f442e50503e73718d324f40",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
         }
     ],
     "wof:id":421196611,
-    "wof:lastmodified":1566654456,
+    "wof:lastmodified":1582359452,
     "wof:name":"Osogbo",
     "wof:parent_id":85675367,
     "wof:placetype":"county",

--- a/data/421/197/067/421197067.geojson
+++ b/data/421/197/067/421197067.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009901,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06ccc5ca4d869ab5e754732aa96d3949",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421197067,
-    "wof:lastmodified":1566654459,
+    "wof:lastmodified":1582359452,
     "wof:name":"Kaduna South",
     "wof:parent_id":85675405,
     "wof:placetype":"county",

--- a/data/421/198/553/421198553.geojson
+++ b/data/421/198/553/421198553.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459009952,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb10c527b6c440371efae235deaf8c36",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421198553,
-    "wof:lastmodified":1566654455,
+    "wof:lastmodified":1582359452,
     "wof:name":"Daura",
     "wof:parent_id":1108563221,
     "wof:placetype":"locality",

--- a/data/421/200/121/421200121.geojson
+++ b/data/421/200/121/421200121.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459010012,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0fcb40e763cd83b5dfe5c90dc8574375",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421200121,
-    "wof:lastmodified":1566654461,
+    "wof:lastmodified":1582359452,
     "wof:name":"Amuwo-Odofin",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/421/200/123/421200123.geojson
+++ b/data/421/200/123/421200123.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459010012,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a6686298a3ffdaf4d00145b9829f24b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421200123,
-    "wof:lastmodified":1566654461,
+    "wof:lastmodified":1582359452,
     "wof:name":"Kaduna North",
     "wof:parent_id":85675405,
     "wof:placetype":"county",

--- a/data/421/202/215/421202215.geojson
+++ b/data/421/202/215/421202215.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459010109,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d40422888edf71edc10e6fc9efb04d5f",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421202215,
-    "wof:lastmodified":1566654445,
+    "wof:lastmodified":1582359452,
     "wof:name":"Suleja",
     "wof:parent_id":85675349,
     "wof:placetype":"county",

--- a/data/421/204/119/421204119.geojson
+++ b/data/421/204/119/421204119.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459010174,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ad0909ac05615be563627935aa818c0",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421204119,
-    "wof:lastmodified":1566654445,
+    "wof:lastmodified":1582359452,
     "wof:name":"Calabar-Municipal",
     "wof:parent_id":85675331,
     "wof:placetype":"county",

--- a/data/421/204/687/421204687.geojson
+++ b/data/421/204/687/421204687.geojson
@@ -91,6 +91,9 @@
     },
     "wof:country":"NG",
     "wof:created":1459010194,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8266fdc1b5da85f133b803c1b1c8da1",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421204687,
-    "wof:lastmodified":1566654444,
+    "wof:lastmodified":1582359451,
     "wof:name":"Ikere",
     "wof:parent_id":85675361,
     "wof:placetype":"county",

--- a/data/856/327/35/85632735.geojson
+++ b/data/856/327/35/85632735.geojson
@@ -949,7 +949,6 @@
     "src:geom_alt":[
         "meso",
         "mapzen",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1027,7 +1026,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1582359383,
+    "wof:lastmodified":1583240871,
     "wof:name":"Nigeria",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/327/35/85632735.geojson
+++ b/data/856/327/35/85632735.geojson
@@ -948,8 +948,9 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
+        "mapzen",
         "naturalearth",
-        "mapzen"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1004,6 +1005,12 @@
     },
     "wof:country":"NG",
     "wof:country_alpha3":"NGA",
+    "wof:geom_alt":[
+        "meso",
+        "mapzen-reversegeo",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"6a01c38c80dbd88ba9010a1f0c3fd04a",
     "wof:hierarchy":[
         {
@@ -1020,7 +1027,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650853,
+    "wof:lastmodified":1582359383,
     "wof:name":"Nigeria",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/753/01/85675301.geojson
+++ b/data/856/753/01/85675301.geojson
@@ -333,6 +333,9 @@
         "wk:page":"Borno State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e59d417609c1fe766dff1a6d30771e4",
     "wof:hierarchy":[
         {
@@ -350,7 +353,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650851,
+    "wof:lastmodified":1582359381,
     "wof:name":"Borno",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/05/85675305.geojson
+++ b/data/856/753/05/85675305.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Abia State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"515755e9cdff2721cdce83cd541c6ff9",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650848,
+    "wof:lastmodified":1582359380,
     "wof:name":"Abia",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/09/85675309.geojson
+++ b/data/856/753/09/85675309.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Akwa Ibom State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65c63125ed2a82dd65e1f6719a94a0bc",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650850,
+    "wof:lastmodified":1582359381,
     "wof:name":"Akwa lbom",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/15/85675315.geojson
+++ b/data/856/753/15/85675315.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Imo State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"11d05d3821aee62808f4bc1b65bce94e",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650852,
+    "wof:lastmodified":1582359382,
     "wof:name":"Imo",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/17/85675317.geojson
+++ b/data/856/753/17/85675317.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Rivers State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d29ea3a33f1bef02c3b4bec0d9b8e19",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650848,
+    "wof:lastmodified":1582359380,
     "wof:name":"Rivers",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/21/85675321.geojson
+++ b/data/856/753/21/85675321.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Bayelsa State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc326f25781157722d7bf2bc288c81c3",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650849,
+    "wof:lastmodified":1582359381,
     "wof:name":"Bayelsa",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/25/85675325.geojson
+++ b/data/856/753/25/85675325.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Benue State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0441764926bc4554713c343da64d364",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650853,
+    "wof:lastmodified":1582359382,
     "wof:name":"Benue",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/31/85675331.geojson
+++ b/data/856/753/31/85675331.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Cross River State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f772a20b4752117d7c606d0f86fcb52",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650850,
+    "wof:lastmodified":1582359381,
     "wof:name":"Cross River",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/35/85675335.geojson
+++ b/data/856/753/35/85675335.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Taraba State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32595778173c9de8073d648729d46993",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650848,
+    "wof:lastmodified":1582359380,
     "wof:name":"Taraba",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/39/85675339.geojson
+++ b/data/856/753/39/85675339.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Kwara State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bbf6d6f55f588d0b570f5fe716e75990",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650851,
+    "wof:lastmodified":1582359381,
     "wof:name":"Kwara",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/43/85675343.geojson
+++ b/data/856/753/43/85675343.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Lagos State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5df53793c1dd4ce221f7d80b09e8ee4f",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650849,
+    "wof:lastmodified":1582359381,
     "wof:name":"Lagos",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/49/85675349.geojson
+++ b/data/856/753/49/85675349.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Niger State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0487e778415d0e75e51334e94fa8169b",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650853,
+    "wof:lastmodified":1582359382,
     "wof:name":"Niger",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/53/85675353.geojson
+++ b/data/856/753/53/85675353.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Ogun State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a09dbf1148c654e8c9942fb6605b25a3",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650851,
+    "wof:lastmodified":1582359381,
     "wof:name":"Ogun",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/57/85675357.geojson
+++ b/data/856/753/57/85675357.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Ondo State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38323a6444a035a2c051182528c17e3a",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650847,
+    "wof:lastmodified":1582359380,
     "wof:name":"Ondo",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/61/85675361.geojson
+++ b/data/856/753/61/85675361.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Ekiti State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1d2389fee9a03bd265195fc9870902e",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650847,
+    "wof:lastmodified":1582359380,
     "wof:name":"Ekiti",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/67/85675367.geojson
+++ b/data/856/753/67/85675367.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Osun State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"abab073e13c41f0b9a09835b43b5b8d3",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650848,
+    "wof:lastmodified":1582359380,
     "wof:name":"Osun",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/71/85675371.geojson
+++ b/data/856/753/71/85675371.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Oyo State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e79da51fab129ab257dabdc97459bcc7",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650852,
+    "wof:lastmodified":1582359382,
     "wof:name":"Oyo",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/75/85675375.geojson
+++ b/data/856/753/75/85675375.geojson
@@ -324,6 +324,9 @@
         "wk:page":"Anambra State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ba7b341e112f5768582d3caaab7d4bf",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650849,
+    "wof:lastmodified":1582359381,
     "wof:name":"Anambra",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/79/85675379.geojson
+++ b/data/856/753/79/85675379.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Bauchi State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28ed08bd853c7585b8307525cb7637c2",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650852,
+    "wof:lastmodified":1582359382,
     "wof:name":"Bauchi",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/81/85675381.geojson
+++ b/data/856/753/81/85675381.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Gombe State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3403e86c0a386a21f7b7bf40290688f6",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650849,
+    "wof:lastmodified":1582359381,
     "wof:name":"Gombe",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/87/85675387.geojson
+++ b/data/856/753/87/85675387.geojson
@@ -325,6 +325,9 @@
         "wk:page":"Delta State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93670d2efbb86172ec8aebc9c23cfa8e",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650848,
+    "wof:lastmodified":1582359380,
     "wof:name":"Delta",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/91/85675391.geojson
+++ b/data/856/753/91/85675391.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Edo State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd7b5d958a0b9c9205b4cf9c5da0002c",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650850,
+    "wof:lastmodified":1582359381,
     "wof:name":"Edo",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/95/85675395.geojson
+++ b/data/856/753/95/85675395.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Enugu State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac6a2b94d83beaf3de181c2ef0a49979",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650847,
+    "wof:lastmodified":1582359380,
     "wof:name":"Enugu",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/753/99/85675399.geojson
+++ b/data/856/753/99/85675399.geojson
@@ -308,6 +308,9 @@
         "wk:page":"Ebonyi State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50c8e223b35358af911f8874747c28e8",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650852,
+    "wof:lastmodified":1582359382,
     "wof:name":"Ebonyi",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/05/85675405.geojson
+++ b/data/856/754/05/85675405.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Kaduna State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"791d1fc6ec61d7c2cfec25b06a6aef32",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650844,
+    "wof:lastmodified":1582359378,
     "wof:name":"Kaduna",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/07/85675407.geojson
+++ b/data/856/754/07/85675407.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Kogi State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"022f37e41ae66a9533dbfbe0a6773193",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650846,
+    "wof:lastmodified":1582359379,
     "wof:name":"Kogi",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/11/85675411.geojson
+++ b/data/856/754/11/85675411.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Plateau State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"910cc92945a4a09018061976a6e06d5d",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650844,
+    "wof:lastmodified":1582359379,
     "wof:name":"Plateau",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/15/85675415.geojson
+++ b/data/856/754/15/85675415.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Nasarawa State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19c8386f5634781aa2591b2842c437f6",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650846,
+    "wof:lastmodified":1582359379,
     "wof:name":"Nassarawa",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/21/85675421.geojson
+++ b/data/856/754/21/85675421.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Jigawa State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac2d63c8f59857e30887e38c7bbc779f",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650845,
+    "wof:lastmodified":1582359379,
     "wof:name":"Jigawa",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/25/85675425.geojson
+++ b/data/856/754/25/85675425.geojson
@@ -325,6 +325,9 @@
         "wk:page":"Kano State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3fb1df2ba9b6b9d1d715904fbfba01ed",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650846,
+    "wof:lastmodified":1582359380,
     "wof:name":"Kano",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/29/85675429.geojson
+++ b/data/856/754/29/85675429.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Katsina State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3730cb5f4511d900159e5e78b9d3d4a4",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650845,
+    "wof:lastmodified":1582359379,
     "wof:name":"Katsina",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/33/85675433.geojson
+++ b/data/856/754/33/85675433.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Sokoto State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de1cf6989f07202cf5910a1d4e31e55f",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650844,
+    "wof:lastmodified":1582359378,
     "wof:name":"Sokoto",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/39/85675439.geojson
+++ b/data/856/754/39/85675439.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Zamfara State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80246a31e57b8a3f37774d9c3624294e",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650846,
+    "wof:lastmodified":1582359379,
     "wof:name":"Zamfara",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/43/85675443.geojson
+++ b/data/856/754/43/85675443.geojson
@@ -319,6 +319,9 @@
         "wk:page":"Yobe State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ca3e35a33986e7c3879fec7a52985eb",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650845,
+    "wof:lastmodified":1582359379,
     "wof:name":"Yobe",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/47/85675447.geojson
+++ b/data/856/754/47/85675447.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Kebbi State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3854db8e8b2ac794a8c93756dfbc2d6",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650846,
+    "wof:lastmodified":1582359380,
     "wof:name":"Kebbi",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/51/85675451.geojson
+++ b/data/856/754/51/85675451.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Adamawa State"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e84cada64ef1eef89eff603247eddbd0",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650844,
+    "wof:lastmodified":1582359377,
     "wof:name":"Adamawa",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/856/754/57/85675457.geojson
+++ b/data/856/754/57/85675457.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Federal Capital Territory, Nigeria"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a1d5bb9bf37f6710725e496c9cc7183",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1566650843,
+    "wof:lastmodified":1582359377,
     "wof:name":"Federal Capital Territory",
     "wof:parent_id":85632735,
     "wof:placetype":"region",

--- a/data/857/655/97/85765597.geojson
+++ b/data/857/655/97/85765597.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Ikoyi"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aab506d5d4a9d64c6756281723b88429",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566650843,
+    "wof:lastmodified":1582359376,
     "wof:name":"Ikoyi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/09/85802209.geojson
+++ b/data/858/022/09/85802209.geojson
@@ -104,6 +104,9 @@
         "wd:id":"Q5429405"
     },
     "wof:country":"NG",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28023aeef87b61e6ab80cccf21eca371",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566650857,
+    "wof:lastmodified":1582359385,
     "wof:name":"Fagge",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/432/249/890432249.geojson
+++ b/data/890/432/249/890432249.geojson
@@ -370,6 +370,9 @@
     },
     "wof:country":"NG",
     "wof:created":1469051934,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a05557fd4a30f83d6d583bc5da5c084c",
     "wof:hierarchy":[
         {
@@ -381,7 +384,7 @@
         }
     ],
     "wof:id":890432249,
-    "wof:lastmodified":1566654486,
+    "wof:lastmodified":1582359453,
     "wof:name":"Kano",
     "wof:parent_id":1108563193,
     "wof:placetype":"locality",

--- a/data/890/435/377/890435377.geojson
+++ b/data/890/435/377/890435377.geojson
@@ -358,6 +358,9 @@
     },
     "wof:country":"NG",
     "wof:created":1469052065,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4401c2d23422aab9dbdba918214c9d64",
     "wof:hierarchy":[
         {
@@ -369,7 +372,7 @@
         }
     ],
     "wof:id":890435377,
-    "wof:lastmodified":1566654487,
+    "wof:lastmodified":1582359454,
     "wof:name":"Abeokuta",
     "wof:parent_id":1108562907,
     "wof:placetype":"locality",

--- a/data/890/437/283/890437283.geojson
+++ b/data/890/437/283/890437283.geojson
@@ -504,6 +504,9 @@
     },
     "wof:country":"NG",
     "wof:created":1469052145,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"d4f8f47361d8e62caed2c82d847c62b5",
     "wof:hierarchy":[
         {
@@ -515,7 +518,7 @@
         }
     ],
     "wof:id":890437283,
-    "wof:lastmodified":1566654471,
+    "wof:lastmodified":1582359453,
     "wof:name":"Abuja",
     "wof:parent_id":421178395,
     "wof:placetype":"locality",

--- a/data/890/438/755/890438755.geojson
+++ b/data/890/438/755/890438755.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"NG",
     "wof:created":1469052208,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b14ac6baa090031f884284c2f2d961ed",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":890438755,
-    "wof:lastmodified":1566654472,
+    "wof:lastmodified":1582359453,
     "wof:name":"Ifako-Ijaye",
     "wof:parent_id":85675343,
     "wof:placetype":"county",

--- a/data/890/444/289/890444289.geojson
+++ b/data/890/444/289/890444289.geojson
@@ -313,6 +313,9 @@
     },
     "wof:country":"NG",
     "wof:created":1469052464,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c811ecc5de25214edfaf384e5c0860da",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         }
     ],
     "wof:id":890444289,
-    "wof:lastmodified":1566654475,
+    "wof:lastmodified":1582359453,
     "wof:name":"Zaria",
     "wof:parent_id":1108564315,
     "wof:placetype":"locality",

--- a/data/890/444/309/890444309.geojson
+++ b/data/890/444/309/890444309.geojson
@@ -250,6 +250,9 @@
     },
     "wof:country":"NG",
     "wof:created":1469052464,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6f56392e90c525d9d1aff95220501c2f",
     "wof:hierarchy":[
         {
@@ -261,7 +264,7 @@
         }
     ],
     "wof:id":890444309,
-    "wof:lastmodified":1566654474,
+    "wof:lastmodified":1582359453,
     "wof:name":"Katsina",
     "wof:parent_id":1108563793,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.