### PR TITLE
Name updates

### DIFF
--- a/data/112/588/038/7/1125880387.geojson
+++ b/data/112/588/038/7/1125880387.geojson
@@ -28,11 +28,17 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u062f\u0648\u0646\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u062f\u0648\u0646\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0627\u062f\u0648\u0646\u0627"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u0434\u0443\u043d\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0430\u0434\u0443\u043d\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09a6\u09c1\u09a8\u09be"
@@ -130,6 +136,9 @@
     "name:mar_x_preferred":[
         "\u0915\u0926\u0941\u0928\u093e"
     ],
+    "name:mlg_x_preferred":[
+        "Kaduna"
+    ],
     "name:msa_x_preferred":[
         "Kaduna"
     ],
@@ -208,6 +217,18 @@
     "name:yor_x_preferred":[
         "K\u00e0d\u00fan\u00e1"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5361\u675c\u7eb3"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5361\u675c\u7d0d"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5361\u675c\u7eb3"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5361\u675c\u7d0d"
+    ],
     "name:zho_x_preferred":[
         "\u5361\u675c\u7d0d"
     ],
@@ -228,8 +249,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675405,
-        421200123
+        421200123,
+        85675405
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -250,7 +271,7 @@
         }
     ],
     "wof:id":1125880387,
-    "wof:lastmodified":1566654493,
+    "wof:lastmodified":1587429037,
     "wof:name":"Kaduna",
     "wof:parent_id":421200123,
     "wof:placetype":"locality",

--- a/data/112/598/811/1/1125988111.geojson
+++ b/data/112/598/811/1/1125988111.geojson
@@ -40,6 +40,9 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0406\u0431\u0430\u0434\u0430\u043d"
     ],
+    "name:bel_x_variant":[
+        "\u0406\u0431\u0430\u0434\u0430\u043d"
+    ],
     "name:ben_x_preferred":[
         "\u0987\u09ac\u09be\u09a6\u09be\u09a8"
     ],
@@ -196,6 +199,12 @@
     "name:spa_x_preferred":[
         "Ibad\u00e1n"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0418\u0431\u0430\u0434\u0430\u043d"
+    ],
+    "name:srp_el_x_preferred":[
+        "Ibadan"
+    ],
     "name:srp_x_preferred":[
         "\u0418\u0431\u0430\u0434\u0430\u043d"
     ],
@@ -241,6 +250,18 @@
     "name:yor_x_preferred":[
         "\u00ccb\u00e0d\u00e0n"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u4f0a\u5df4\u4e39"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u4f0a\u5df4\u4e39"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u4f0a\u5df4\u4e39"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u4f0a\u5df4\u4e39"
+    ],
     "name:zho_x_preferred":[
         "\u4f0a\u5df4\u4e39"
     ],
@@ -261,8 +282,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675371,
-        1108563487
+        1108563487,
+        85675371
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -283,7 +304,7 @@
         }
     ],
     "wof:id":1125988111,
-    "wof:lastmodified":1566654495,
+    "wof:lastmodified":1587429038,
     "wof:name":"Ibadan",
     "wof:parent_id":1108563487,
     "wof:placetype":"locality",

--- a/data/122/619/340/3/1226193403.geojson
+++ b/data/122/619/340/3/1226193403.geojson
@@ -83,7 +83,7 @@
         "Bundi"
     ],
     "name:ori_x_preferred":[
-        "\u0b2c\u0b41\u0b28\u0b4d\u0b26\u0b3f "
+        "\u0b2c\u0b41\u0b28\u0b4d\u0b26\u0b3f"
     ],
     "name:pol_x_preferred":[
         "Bundi"
@@ -113,8 +113,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675301,
-        1108563437
+        1108563437,
+        85675301
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -132,7 +132,7 @@
         }
     ],
     "wof:id":1226193403,
-    "wof:lastmodified":1566656030,
+    "wof:lastmodified":1587163116,
     "wof:name":"Bundi",
     "wof:parent_id":1108563437,
     "wof:placetype":"locality",

--- a/data/125/952/780/7/1259527807.geojson
+++ b/data/125/952/780/7/1259527807.geojson
@@ -84,7 +84,7 @@
         "Bundi"
     ],
     "name:ori_x_preferred":[
-        "\u0b2c\u0b41\u0b28\u0b4d\u0b26\u0b3f "
+        "\u0b2c\u0b41\u0b28\u0b4d\u0b26\u0b3f"
     ],
     "name:pol_x_preferred":[
         "Bundi"
@@ -114,8 +114,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675451,
-        1108563963
+        1108563963,
+        85675451
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -133,7 +133,7 @@
         }
     ],
     "wof:id":1259527807,
-    "wof:lastmodified":1566655552,
+    "wof:lastmodified":1587163117,
     "wof:name":"Bundi",
     "wof:parent_id":1108563963,
     "wof:placetype":"locality",

--- a/data/421/175/479/421175479.geojson
+++ b/data/421/175/479/421175479.geojson
@@ -114,7 +114,7 @@
         "\u041e\u0432\u043e"
     ],
     "name:sin_x_preferred":[
-        "\u0d94\u0dc0\u0ddd "
+        "\u0d94\u0dc0\u0ddd"
     ],
     "name:spa_x_preferred":[
         "Owo"
@@ -126,7 +126,7 @@
         "\u0b93\u0b92"
     ],
     "name:tam_x_variant":[
-        "\u0b93\u0b92 "
+        "\u0b93\u0b92"
     ],
     "name:tel_x_preferred":[
         "\u0c35\u0c4b\u0c35\u0c4d"
@@ -144,7 +144,7 @@
         "\u0648\u0648\u0648 \u060c \u0646\u0627\u0626\u06cc\u062c\u06cc\u0631\u06cc\u0627"
     ],
     "name:urd_x_variant":[
-        "\u0648\u0648\u0648 "
+        "\u0648\u0648\u0648"
     ],
     "name:vep_x_preferred":[
         "Ovo"
@@ -277,8 +277,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675357,
-        1108564257
+        1108564257,
+        85675357
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -301,7 +301,7 @@
         }
     ],
     "wof:id":421175479,
-    "wof:lastmodified":1566654452,
+    "wof:lastmodified":1587163137,
     "wof:name":"Owo",
     "wof:parent_id":1108564257,
     "wof:placetype":"locality",

--- a/data/421/189/725/421189725.geojson
+++ b/data/421/189/725/421189725.geojson
@@ -26,6 +26,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a\u0646"
     ],
+    "name:azb_x_preferred":[
+        "\u0628\u0646\u06cc\u0646"
+    ],
     "name:bel_x_preferred":[
         "\u0411\u0435\u043d\u0456\u043d-\u0421\u0456\u0446\u0456"
     ],
@@ -59,6 +62,9 @@
     "name:epo_x_preferred":[
         "Beninurbo"
     ],
+    "name:eus_x_preferred":[
+        "Benin City"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u0646\u06cc\u0646"
     ],
@@ -73,6 +79,9 @@
     ],
     "name:fra_x_variant":[
         "Benin"
+    ],
+    "name:gle_x_preferred":[
+        "Cathair Bheinin"
     ],
     "name:glg_x_preferred":[
         "Benin City"
@@ -188,6 +197,9 @@
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0ba9\u0bbf\u0ba9\u0bcd \u0ba8\u0b95\u0bb0\u0bae\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0baa\u0bc6\u0ba9\u0bbf\u0ba9\u0bcd  \u0ba8\u0b95\u0bb0\u0bae\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c46\u0c28\u0c3f\u0c28\u0c4d \u0c28\u0c17\u0c30\u0c02"
     ],
@@ -215,8 +227,23 @@
     "name:vie_x_preferred":[
         "Th\u00e0nh ph\u1ed1 Benin"
     ],
+    "name:war_x_preferred":[
+        "Benin"
+    ],
     "name:yor_x_preferred":[
         "\u00ccl\u00fa Benin"
+    ],
+    "name:zho_cn_x_preferred":[
+        "\u8d1d\u5b81\u57ce"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u8c9d\u5be7\u57ce"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u8d1d\u5b81\u57ce"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u8c9d\u5357\u57ce"
     ],
     "name:zho_x_preferred":[
         "\u8d1d\u5b81\u57ce"
@@ -247,8 +274,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675391,
-        421188929
+        421188929,
+        85675391
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -274,7 +301,7 @@
         }
     ],
     "wof:id":421189725,
-    "wof:lastmodified":1566654449,
+    "wof:lastmodified":1587429036,
     "wof:name":"Benin City",
     "wof:parent_id":421188929,
     "wof:placetype":"locality",

--- a/data/856/327/35/85632735.geojson
+++ b/data/856/327/35/85632735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":74.929712,
-    "geom:area_square_m":912829883971.062134,
+    "geom:area_square_m":912829885741.875488,
     "geom:bbox":"2.676932,4.275389,14.677982,13.885645",
     "geom:latitude":9.591652,
     "geom:longitude":8.101818,
@@ -59,6 +59,9 @@
     "name:arg_x_preferred":[
         "Nicheria"
     ],
+    "name:ary_x_preferred":[
+        "\u0646\u064a\u062c\u064a\u0631\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0646\u0627\u064a\u062c\u064a\u0631\u064a\u0627"
     ],
@@ -88,6 +91,9 @@
     ],
     "name:bam_x_variant":[
         "Nizeriya"
+    ],
+    "name:ban_x_preferred":[
+        "Nigeria"
     ],
     "name:bar_x_preferred":[
         "Nigeria"
@@ -164,6 +170,12 @@
     "name:dan_x_preferred":[
         "Nigeria"
     ],
+    "name:deu_at_x_preferred":[
+        "Nigeria"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Nigeria"
+    ],
     "name:deu_x_preferred":[
         "Nigeria"
     ],
@@ -184,6 +196,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039d\u03b9\u03b3\u03b7\u03c1\u03af\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Nigeria"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Nigeria"
     ],
     "name:eng_x_colloquial":[
         "Naija"
@@ -254,6 +272,9 @@
     ],
     "name:gan_x_preferred":[
         "\u5c3c\u65e5\u5229\u4e9e"
+    ],
+    "name:gcr_x_preferred":[
+        "Nij\u00e9rya"
     ],
     "name:ger_x_variant":[
         "Bundesrepublik Nigeria"
@@ -601,6 +622,9 @@
     "name:pol_x_preferred":[
         "Nigeria"
     ],
+    "name:por_br_x_preferred":[
+        "Nig\u00e9ria"
+    ],
     "name:por_x_preferred":[
         "Nig\u00e9ria"
     ],
@@ -688,6 +712,12 @@
     "name:srd_x_preferred":[
         "Nig\u00e9ria"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u041d\u0438\u0433\u0435\u0440\u0438\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Nigerija"
+    ],
     "name:srp_x_preferred":[
         "\u041d\u0438\u0433\u0435\u0440\u0438\u0458\u0430"
     ],
@@ -715,6 +745,9 @@
     "name:szl_x_preferred":[
         "\u0143igeryjo"
     ],
+    "name:szy_x_preferred":[
+        "Nigeria"
+    ],
     "name:tam_x_preferred":[
         "\u0ba8\u0bc8\u0b9c\u0bc0\u0bb0\u0bbf\u0baf\u0bbe"
     ],
@@ -723,6 +756,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c28\u0c48\u0c1c\u0c40\u0c30\u0c3f\u0c2f\u0c3e"
+    ],
+    "name:tet_x_preferred":[
+        "Nij\u00e9ria"
     ],
     "name:tgk_x_preferred":[
         "\u041d\u0438\u04b7\u0435\u0440\u0438\u044f"
@@ -765,6 +801,9 @@
     ],
     "name:tur_x_preferred":[
         "Nijerya"
+    ],
+    "name:twi_x_preferred":[
+        "Nigeria"
     ],
     "name:udm_x_preferred":[
         "\u041d\u0438\u0433\u0435\u0440\u0438\u044f"
@@ -853,8 +892,17 @@
     "name:zha_x_preferred":[
         "Nizywlihya"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5c3c\u65e5\u5229\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5c3c\u65e5\u5229\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Nigeria"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5948\u53ca\u5229\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u5948\u53ca\u5229\u4e9e"
@@ -1027,7 +1075,7 @@
         "eng",
         "yor"
     ],
-    "wof:lastmodified":1583797401,
+    "wof:lastmodified":1587429034,
     "wof:name":"Nigeria",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/418/153/890418153.geojson
+++ b/data/890/418/153/890418153.geojson
@@ -128,7 +128,7 @@
         "\u0b92\u0baa\u0bcd\u0baa\u0bbe"
     ],
     "name:tam_x_variant":[
-        "\u0b92\u0baa\u0bcd\u0baa\u0bbe "
+        "\u0b92\u0baa\u0bcd\u0baa\u0bbe"
     ],
     "name:tel_x_preferred":[
         "\u0c06\u0c2b\u0c40"
@@ -146,7 +146,7 @@
         "\u0648\u0641\u0627 \u060c \u0646\u0627\u0626\u06cc\u062c\u06cc\u0631\u06cc\u0627"
     ],
     "name:urd_x_variant":[
-        "\u0648\u0641\u0627 "
+        "\u0648\u0641\u0627"
     ],
     "name:vie_x_preferred":[
         "Offa"
@@ -162,8 +162,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675339,
-        1108564099
+        1108564099,
+        85675339
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -185,7 +185,7 @@
         }
     ],
     "wof:id":890418153,
-    "wof:lastmodified":1566654481,
+    "wof:lastmodified":1587163142,
     "wof:name":"Offa",
     "wof:parent_id":1108564099,
     "wof:placetype":"locality",

--- a/data/890/432/249/890432249.geojson
+++ b/data/890/432/249/890432249.geojson
@@ -25,11 +25,20 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0646\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0646\u0648"
+    ],
     "name:ast_x_preferred":[
         "Kano"
     ],
+    "name:azb_x_preferred":[
+        "\u06a9\u0627\u0646\u0648\u060c \u0646\u06cc\u062c\u0631\u06cc\u0647"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0430\u043d\u043e"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0430\u043d\u043e"
     ],
     "name:ben_x_preferred":[
         "\u0995\u09cd\u09af\u09be\u09a8\u09c7\u09cb"
@@ -199,6 +208,15 @@
     "name:spa_x_preferred":[
         "Kano"
     ],
+    "name:sqi_x_preferred":[
+        "Kano"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041a\u0430\u043d\u043e"
+    ],
+    "name:srp_el_x_preferred":[
+        "Kano"
+    ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u043d\u043e"
     ],
@@ -243,6 +261,18 @@
     ],
     "name:yor_x_preferred":[
         "K\u00e1n\u00f2"
+    ],
+    "name:zho_cn_x_preferred":[
+        "\u5361\u8bfa\u5e02"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5361\u8afe\u5e02"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5361\u8bfa\u5e02"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5361\u8afe\u5e02"
     ],
     "name:zho_x_preferred":[
         "\u5361\u8afe"
@@ -354,8 +384,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675425,
-        1108563193
+        1108563193,
+        85675425
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -384,7 +414,7 @@
         }
     ],
     "wof:id":890432249,
-    "wof:lastmodified":1582359453,
+    "wof:lastmodified":1587429037,
     "wof:name":"Kano",
     "wof:parent_id":1108563193,
     "wof:placetype":"locality",

--- a/data/890/437/281/890437281.geojson
+++ b/data/890/437/281/890437281.geojson
@@ -133,6 +133,9 @@
     "name:frp_x_preferred":[
         "Lagos"
     ],
+    "name:frr_x_preferred":[
+        "Lagos"
+    ],
     "name:fry_x_preferred":[
         "Lagos"
     ],
@@ -445,6 +448,12 @@
     "name:yue_x_preferred":[
         "\u62c9\u54e5\u65af"
     ],
+    "name:zho_hk_x_preferred":[
+        "\u62c9\u54e5\u65af"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u62c9\u54e5\u65af"
+    ],
     "name:zho_x_preferred":[
         "\u62c9\u54e5\u65af"
     ],
@@ -460,8 +469,8 @@
     "wof:belongsto":[
         102191573,
         85632735,
-        85675343,
-        1108563883
+        1108563883,
+        85675343
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -483,7 +492,7 @@
         }
     ],
     "wof:id":890437281,
-    "wof:lastmodified":1566654471,
+    "wof:lastmodified":1587429036,
     "wof:name":"Lagos",
     "wof:parent_id":1108563883,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.